### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+calculator-backend/
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:latest AS dep-download
+
+WORKDIR /usr/src/app
+COPY ./calculator-ui /usr/src/app
+
+RUN npm i
+
+FROM dep-download AS build
+
+ARG REACT_APP_BACKEND_URL
+ENV REACT_APP_BACKEND_URL $REACT_APP_BACKEND_URL
+
+RUN npm run build
+
+FROM nginx:alpine AS runtime
+
+WORKDIR /app
+
+COPY --from=build /usr/src/app/build/. .
+
+COPY ./nginx.conf /etc/nginx/nginx.conf
+EXPOSE 3000
+

--- a/calculator-backend/Dockerfile
+++ b/calculator-backend/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:latest AS dep
+
+WORKDIR /usr/src/app
+COPY ./ /usr/src/app
+
+RUN mvn dependency:resolve
+
+FROM dep AS build
+
+RUN mvn install
+
+FROM openjdk:11 AS runtime
+COPY --from=build /usr/src/app/target /usr/src/app/target
+
+CMD ["java", "-jar", "/usr/src/app/target/quarkus-app/quarkus-run.jar"]
+

--- a/calculator-ui/.dockerignore
+++ b/calculator-ui/.dockerignore
@@ -1,0 +1,1 @@
+node_modules*

--- a/calculator-ui/Dockerfile
+++ b/calculator-ui/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:latest as dep-download
+
+WORKDIR /usr/src/app
+COPY ./ /usr/src/app
+
+RUN npm i
+
+FROM dep-download AS build
+ARG REACT_APP_BACKEND_URL
+ENV REACT_APP_BACKEND_URL $REACT_APP_BACKEND_URL
+
+RUN npm run build
+
+## https://lipanski.com/posts/smallest-docker-image-static-website
+FROM lipanski/docker-static-website:latest as runtime
+
+COPY --from=build /usr/src/app/build/. .
+
+#CMD ["/busybox", "httpd", "-f", "-v", "-p", "3000", "-c", "httpd.conf"]
+

--- a/calculator-ui/src/CalcForm.js
+++ b/calculator-ui/src/CalcForm.js
@@ -841,7 +841,7 @@ class CalcForm extends Component {
 
     console.log(payload);
     
-    fetch('http://localhost:8090/api/amqstreamssizing', {
+    fetch((process.env.REACT_APP_BACKEND_URL || 'http://localhost:8090/api') + '/amqstreamssizing', {
       method: 'POST',
       body: JSON.stringify(payload),
       headers: {

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -1,0 +1,13 @@
+---
+version: "3"
+
+services:
+  backend:
+    build: ./calculator-backend
+  nginx:
+    build:
+      context: .
+      args:
+      - REACT_APP_BACKEND_URL=/api
+    ports:
+    - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+version: "3"
+
+services:
+  backend:
+    build: ./calculator-backend
+    ports:
+    - 8090:8090
+  frontend:
+    build: ./calculator-ui
+    ports:
+    - 3000:3000

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,40 @@
+events {
+  worker_connections 4096;
+}
+
+http {
+
+  #include /etc/nginx/fastcgi.conf;
+  include /etc/nginx/mime.types;
+  #include /etc/nginx/uwsgi_params;
+  #include /etc/nginx/modules;
+  #include /etc/nginx/fastcgi_params;
+  #include /etc/nginx/scgi_params;
+
+  index    index.html index.htm;
+  default_type application/octet-stream;
+  sendfile     on;
+  tcp_nopush   on;
+
+  upstream backend {
+    server backend:8090;
+  }
+
+  server {
+    listen 3000;
+    listen [::]:3000;
+
+    server_name _;
+    autoindex off;
+    server_tokens off;
+
+    root /app;
+    gzip_static on;
+
+    location / {
+    }
+    location /api {
+      proxy_pass http://backend/api;
+    }
+  }
+}


### PR DESCRIPTION
Simple docker implementation

Run `docker compose up` and everything should build and be served.

Alternatively, run `docker compose -f docker-compose-nginx.yml up` to build a nginx image that serves static files, and acts as a reverse proxy for the Java API.